### PR TITLE
Dynamically load GEOSPreparedContainsXY where available

### DIFF
--- a/geos_perf.h
+++ b/geos_perf.h
@@ -84,6 +84,11 @@ size_t geomlist_size(GEOSGeometryList* gl);
 GEOSGeometry* geomlist_pop(GEOSGeometryList* gl);
 const GEOSGeometry* geomlist_get(GEOSGeometryList* gl, size_t i);
 
+int geos_version_major();
+int geos_version_minor();
+
+extern void* geos_lib_handle;
+
 /**
 * Read a wkt.gz file, with one wkt geometry per line, gzipped.
 * File name is relative to the data directory.


### PR DESCRIPTION
This is my attempt to update `geos-performance` so we can look at how https://github.com/libgeos/geos/pull/674 affects point-in-polygon performance assuming that client code is updated to use `GEOSPreparedContainsXY`.

It works well for me and gives the desired "no impact on performance" answer. I don't know what you think about the complexity it adds, or how if this code even runs on MacOS. But I think this presents an alternative to the "only use functions available in the oldest version you want to test" limitation.